### PR TITLE
(fix) Fix and streamline various functionalities

### DIFF
--- a/api/static/js/controllers/BucketListController.js
+++ b/api/static/js/controllers/BucketListController.js
@@ -6,8 +6,13 @@ BucketlistApp.controller('BucketlistController',
 		var pageRequested = function (pageClicked) {
 			nextPage = pageClicked;
 			$scope.currentpage = pageClicked;
+			var queryStrings = {
+				limit: itemsPerPage,
+				page: pageClicked,
+				q: $scope.search_bucketlists
+			};
 
-			BucketlistFactory.Bucketlist.getAll({limit: itemsPerPage, page: pageClicked}).$promise.then(
+			BucketlistFactory.Bucketlist.getAll(queryStrings).$promise.then(
 				function (response) {
 					$scope.bucketlists = response;
 				},
@@ -36,7 +41,7 @@ BucketlistApp.controller('BucketlistController',
 		};
 
 		$scope.loadBucketlists = function (eventObj) {
-
+			nextPage = 1; pages = 1; itemsPerPage = 20;
 			if ( typeof($scope.custom_page_size) === 'undefined') {
 				itemsPerPage = 20;
 			} else {
@@ -53,7 +58,16 @@ BucketlistApp.controller('BucketlistController',
 					itemsPerPage = 100;
 				}
 
-				BucketlistFactory.Bucketlist.getAll({limit: itemsPerPage}).$promise.then(
+				var queryStrings = {};
+				if ($scope.search_bucketlists) {
+					queryStrings.q = $scope.search_bucketlists;
+					queryStrings.limit = itemsPerPage;
+				} else {
+					queryStrings.limit = itemsPerPage;
+				}
+
+
+				BucketlistFactory.Bucketlist.getAll(queryStrings).$promise.then(
 					function (response) {
 						$scope.bucketlists = response;
 						if (typeof(response.results) === 'object') {

--- a/api/static/js/controllers/LoginController.js
+++ b/api/static/js/controllers/LoginController.js
@@ -2,6 +2,14 @@ BucketlistApp.controller('LoginController',
 	['$scope', '$http', '$window', '$cookies', '$rootScope', 'APIAccessFactory',
 	function ($scope, $http, $window, $cookies, $rootScope, APIAccessFactory) {
 
+		// if someone is (had) logged in, show sign in button and remove existing
+		// auth token
+		if ($cookies.get('Authorization')) {
+			$rootScope.showSignIn = true;
+			$cookies.remove('Authorization');
+			$cookies.remove('Username');
+		}
+
 		$scope.signUp = function() {
 			if (!$scope.new_username) {
 				$scope.signUpResponse = 'Sign Up username not provided';

--- a/api/static/js/services/authorization_service.js
+++ b/api/static/js/services/authorization_service.js
@@ -18,9 +18,9 @@ BucketlistApp.service('AuthorizationService', ['$cookies', '$window', '$rootScop
 
 			if (response.status === 401) {
 				if (response.data.detail === 'Signature has expired.') {
-					sweetAlert("Your current session has expired!", "Please login again to refresh it.", "error");
 					$window.location.href = "/#/login/";
-					$rootScope.signOutLabel = "Sign Out";
+					sweetAlert("Your current session has expired!", "Please login again to refresh it.", "error");
+
 				} else if (response.data.detail === 'Authentication credentials were not provided.') {
 					sweetAlert("Authentication required!", "You need to be authenticated to perform this action", "error");
 					$window.location.href = "/#/login/";

--- a/api/static/views/bucketlist.html
+++ b/api/static/views/bucketlist.html
@@ -34,7 +34,7 @@ $(document).ready(function(){
     <!-- start search div -->
     <div class="col s5">
       <div class="input-field col s6">
-        <input placeholder="Search Bucketlists" id="search_bucketlists" type="text" class="validate" ng-model="search_bucketlists">
+        <input placeholder="Search Bucketlists" id="search_bucketlists" type="text" class="validate" ng-model="search_bucketlists" ng-keypress="loadBucketlists($event)">
         <label for="search_bucketlists" style="color: #000000;">Search Bucketlists by name</label>
       </div>
     </div>
@@ -53,7 +53,7 @@ $(document).ready(function(){
     <div class="center-align">
       <ul class="pagination">
       <li class="waves-effect"><a ng-click="leftChevron()"><i class="material-icons">chevron_left</i></a></li>
-      <li class="waves-effect" ng-click="setpage($index + 1)" ng-repeat="page in pages track by $index"><a  href="">[[$index + 1]]</a></li>
+      <li ng-class="currentpage == $index+1 ? 'active teal lighten-2': 'waves-effect'"  ng-click="setpage($index + 1)" ng-repeat="page in pages track by $index"><a  href="">[[$index + 1]]</a></li>
       <li class="waves-effect"><a ng-click="rightChevron()"><i class="material-icons">chevron_right</i></a></li>
     </ul>
     </div>
@@ -63,7 +63,7 @@ $(document).ready(function(){
   <!-- Start bucketlist displaysection -->
   <div class="row">
     <div class="container">
-      <div id="bucketlist_div" ng-show="showBucketlist" ng-repeat="bucketlist in bucketlists.results | filter:search_bucketlists" class="col s4">
+      <div id="bucketlist_div" ng-show="showBucketlist" ng-repeat="bucketlist in bucketlists.results" class="col s4">
         <h6><strong>[[ bucketlist.name ]]</strong></h6>
         <hr>
         <p id="p_bucketlist_items" ng-click="viewItems([[ bucketlist.buck_id ]])">View items</p>

--- a/api/viewsets.py
+++ b/api/viewsets.py
@@ -26,7 +26,7 @@ class BucketListViewSet(viewsets.ModelViewSet):
 
 		search_name = self.request.query_params.get('q', None)
 		if search_name:
-			return BucketList.objects.filter(name=search_name)
+			return BucketList.objects.filter(name__icontains=search_name)
 
 		return BucketList.objects.all()
 


### PR DESCRIPTION
- Remove angular filter and instead filter from backend through query parameter 'q'. Search returns bucketlists whose name matches/contains search string
- Remove authorization token and username information at LoginController to logout any user that may be logged in. Moved this logic from authorization_service
- Apply Angular's ng-class directive to highlight the current page number when scrolling through paginated results
